### PR TITLE
Update docker-java-application Gradle plugin to 3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'application'
   id 'maven'
   id 'osgi'
-  id 'com.bmuschko.docker-java-application' version '3.0.2'
+  id 'com.bmuschko.docker-java-application' version '3.2.1'
   id "nebula.ospackage-application" version "3.6.1"
   id 'org.ajoberstar.grgit' version '1.5.0'
 }


### PR DESCRIPTION
This should fix the error "Could not build image: null" that occurs with newer Docker versions.