### PR TITLE
build(docker): replace Docker base image w/ OpenJDK variant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ distributions {
 
 docker {
   javaApplication {
-    baseImage = 'isuper/java-oracle:server_jre_8'
+    baseImage = 'openjdk:8-jre-slim'
     maintainer = 'Simon Templer "simon@wetransform.to"'
     tag = "wetransform/${project.name}:${project.version}"
   }


### PR DESCRIPTION
The previous base image `isuper/java-oracle:server_jre_8` appears to be no longer available (publicly). This patch replaces it with an OpenJDK 8 JRE image.