### PR TITLE
fixup! build: update baseImage to java 17 for Gradle docker plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,8 @@ distributions {
 docker {
   javaApplication {
     // https://bmuschko.github.io/gradle-docker-plugin/current/user-guide/#extension_2
-    baseImage = 'eclipse-temurin:17-jre-alpine'
+    // switching to jre-jammy as the use pf Alpine as the OS of the hale-cli image breaks derived images that expect Ubuntu
+    baseImage = 'eclipse-temurin:17-jre-jammy'
     maintainer = 'Simon Templer "simon@wetransform.to"'
     images = ["wetransform/${project.name}:${project.version}", "wetransform/${project.name}:latest"]
   }


### PR DESCRIPTION
switching to jre-jammy as the use pf Alpine as the OS of the hale-cli image breaks derived images that expect Ubuntu

ING-3775