### PR TITLE
refactor(docker): restore dockerCopyDistResources task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ docker {
 dockerCreateDockerfile {
   def buildTime = java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ISO_INSTANT);
   label('git.sha': grgit.head().id, 'git.branch': grgit.branch.current.name, 'build.version': version, 'build.time': buildTime)
-
+  instruction 'COPY hale /hale/'
 }
 
 task dockerTagLatest(dependsOn: dockerBuildImage) {}
@@ -280,6 +280,25 @@ groovydoc {
 }
 dependencies {
   jansi 'org.fusesource.jansi:jansi:1.11'
+}
+
+task dockerCopyDistResources(type: Copy) {
+  description "Copies the distribution resources to a temporary directory for image creation."
+  dependsOn installDist
+  from installDist.destinationDir.parentFile
+  into dockerCreateDockerfile.destFile.get().asFile.parentFile
+  exclude "**/lib/${jar.archiveFileName}"
+  into("app-lib") {
+    from jar
+  }
+}
+
+tasks.dockerSyncBuildContext {
+  finalizedBy dockerCopyDistResources
+}
+
+tasks.dockerBuildImage {
+  dependsOn dockerCopyDistResources
 }
 
 // package source into a jar file


### PR DESCRIPTION
Restores the task `dockerCopyDistResources` that was present in earlier versions of gradle-docker-plugin.

Since the upgrade of gradle-docker-plugin, the hale-cli dist version assembled by the application plugin was no longer added to the `/hale` directory of the created Docker image. This functionality is restored here.

SVC-1398