### PR TITLE
ci: adapt usage of gradle-library workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   check:
-    uses: wetransform/gha-workflows/.github/workflows/gradle-library-check.yml@master
+    uses: wetransform/gha-workflows/.github/workflows/gradle-library-check.yml@ef7e7ff0d5f77914d591c783f3dcf854e3c4e204
     with:
       java-version: 17
 
   docker:
-    uses: wetransform/gha-workflows/.github/workflows/gradle-service-check.yml@master
+    uses: wetransform/gha-workflows/.github/workflows/gradle-service-check.yml@ef7e7ff0d5f77914d591c783f3dcf854e3c4e204
     with:
       java-version: 17
       image-tag: wetransform/hale-cli:latest # image to scan

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   artifacts:
-    uses: wetransform/gha-workflows/.github/workflows/gradle-library.yml@master
+    uses: wetransform/gha-workflows/.github/workflows/gradle-library.yml@ef7e7ff0d5f77914d591c783f3dcf854e3c4e204
     with:
       java-version: 17
       build-tasks: clean check distZip buildDeb
@@ -26,7 +26,7 @@ jobs:
 
   docker:
     # FIXME both master and devel will push latest - only one should
-    uses: wetransform/gha-workflows/.github/workflows/gradle-service-publish.yml@master
+    uses: wetransform/gha-workflows/.github/workflows/gradle-service-publish.yml@ef7e7ff0d5f77914d591c783f3dcf854e3c4e204
     with:
       java-version: 17
       image-tag: wetransform/hale-cli:latest # image to scan

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ jobs:
     uses: wetransform/gha-workflows/.github/workflows/gradle-library.yml@master
     with:
       java-version: 17
-      gradle-tasks: clean check distZip buildDeb publish
+      build-tasks: clean check distZip buildDeb
+      publish-tasks: publish
       upload-artifact-path: build/distributions
       upload-artifact-name: distributions
     secrets:


### PR DESCRIPTION
As the `gradle-tasks` parameter of the referenced `gradle-library` was removed and replaced by `build-tasks` and `publish-tasks` in https://github.com/wetransform/gha-workflows/commit/a30e8dee7854867573a1a5b96619cdedb6b55083 the workflow here must be adapted accordingly.

SVC-1812