### PR TITLE
ci: pass Artifactory user and password to publish task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
       upload-artifact-name: distributions
     secrets:
       SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
 
   docker:
     # FIXME both master and devel will push latest - only one should


### PR DESCRIPTION
From [GHA log](https://github.com/halestudio/hale-cli/actions/runs/8986524786/job/24682845610#step:15:66):

```
Execution failed for task ':publishMavenJavaPublicationToMavenRepository'.
> Failed to publish publication 'mavenJava' to repository 'maven'
   > Could not PUT 'https://artifactory.wetransform.to/artifactory/libs-snapshot-local/to/wetransform/hale-cli/5.2.0-SNAPSHOT/maven-metadata.xml'. Received status code 401 from server: 
```